### PR TITLE
Send tuple instead of string for s3 to json file

### DIFF
--- a/ipyrad/assemble/cluster_within.py
+++ b/ipyrad/assemble/cluster_within.py
@@ -1040,8 +1040,8 @@ def reconcat(data, sample):
     chunks.sort(key=lambda x: int(x.rsplit("_", 1)[-1][:-8]))
     LOGGER.info("chunk %s", chunks)
     ## concatenate finished reads
-    sample.files.clusters = os.path.join(data.dirs.clusts,
-                                         sample.name+".clustS.gz")
+    sample.files.clusters = [(os.path.join(data.dirs.clusts,
+                                         sample.name+".clustS.gz"),0)]
     ## reconcats aligned clusters
     with gzip.open(sample.files.clusters, 'wb') as out:
         for fname in chunks:


### PR DESCRIPTION
Taking as example how the sample filenames are sent from `rawedit.py` to the json file this may work to fix merging of multiple assemblies after step 3 (UNTESTED)