### PR TITLE
Better handling of final alignments when they contain merged and unme…

### DIFF
--- a/ipyrad/assemble/cluster_across.py
+++ b/ipyrad/assemble/cluster_across.py
@@ -102,6 +102,7 @@ def muscle_align_across(data, samples, chunk):
                     indels[sidx, ldx, :thislen] = aseqs[idx, :thislen] == "-"
 
             else:
+                seqs = [i.replace('nnnn','') for i in seqs]
                 string1 = muscle_call(data, names, seqs)
                 anames, aseqs = parsemuscle(data, string1)
                 ## aseqs is the length of the data


### PR DESCRIPTION
…rged sequences

Similar to the recent change in step 3, this modification would remove the separator `nnnn` when the locus alignment contains merged and unmerged sequences