### PR TITLE
Edits to Rep.parse()

### DIFF
--- a/ipyrad/analysis/structure.py
+++ b/ipyrad/analysis/structure.py
@@ -875,15 +875,16 @@ class Rep(object):
 
                 elif popline:
                     ## check if sample is supervised...
+                    ## pidx not work when structure file contains pop data (but no popflags) for more than kpops
                     abc = line.strip().split()
-                    prop = ["0.000"] * self.kpop
-                    pidx = int(abc[3]) - 1
-                    prop[pidx] = "1.000"
+                    #prop = ["0.000"] * self.kpop
+                    #pidx = int(abc[3]) - 1
+                    #prop[pidx] = "1.000"
                     outstr = "{}{}{}".format(
-                        " ".join([abc[0], abc[0], abc[2], 
-                                  abc[0].split('.')[0]]),
+                        " ".join([abc[0], abc[1], abc[2], 
+                                  abc[3].split('.')[0]]),
                         " :  ",
-                        " ".join(prop)
+                        " ".join(abc[5:)
                     )
                     self.inds += 1
                     stable += outstr+"\n"


### PR DESCRIPTION
Did not work when running a Structure analysis with popdata (but all popflags set to 0). Parse seems to be using k length instead of number of populations. Also, get_evanno_table() threw an error because the label in the .indfile was incorrect, so I changed the definition of outstr.