### PR TITLE
add missing requirement: dask[array]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ pandas>=0.16
 h5py
 networkx
 dask
+dask[array]
 pysam>=0.10.0
 setuptools
 


### PR DESCRIPTION
Requirement/dependency `dask[array]` was missing for installation via pip.