### PR TITLE
Fixing mismatch of #SBATCH and command parameters

### DIFF
--- a/newdocs/HPC_script.rst
+++ b/newdocs/HPC_script.rst
@@ -111,7 +111,7 @@ And here is an example *sbatch* script:
     cd $HOME/ipyrad-analyses/
 
     ## call ipyrad on your params file
-    ipyrad -p params-test.txt -s 1234567 -c 20
+    ipyrad -p params-test.txt -s 1234567 -c ${SLURM_CPUS_PER_TASK}
 
 .. parsed-literal::
     ## submit the qsub script
@@ -178,7 +178,7 @@ And here is an example *sbatch* script:
     cd $HOME/ipyrad-analyses/
 
     ## call ipyrad on your params file
-    ipyrad -p params-test.txt -s 1234567 -c 80 --MPI
+    ipyrad -p params-test.txt -s 1234567 -c ${SLURM_NTASKS} --MPI
 
 .. parsed-literal::
     ## submit the qsub script


### PR DESCRIPTION
Previously, there was a mismatch between the `#SBATCH` lines (32 cores reserved) and the `ipyrad` parameters (20 cores used). This sets the `ipyrad` parameters to match the `#SBATCH` automatically. There's probably an equivalent for PBS, but I don't have easy access to test that.