### PR TITLE
WIP: Notebook is already a dependency of iPyrad

### DIFF
--- a/newdocs/3-installation.rst
+++ b/newdocs/3-installation.rst
@@ -70,6 +70,7 @@ The following Python packages are installed as dependencies of ipyrad:
     - pandas
     - h5py
     - mpi4py
+    - notebook
     - numba
     - ipyparallel
     - pysam


### PR DESCRIPTION
Hey, Deren et al.

Was working with Dr. Hurt earlier on installing a fresh iPyrad environment, and I noticed that both `mpi4py` and `notebook` are dependencies of iPyrad.

This isn't a complete PR, since I don't want to assume how you'd edit the "Recommended additional packages" section now that both example packages listed there are already included with iPyrad.