### PR TITLE
kmeans imputation niters fix

### DIFF
--- a/ipyrad/analysis/pca.py
+++ b/ipyrad/analysis/pca.py
@@ -269,7 +269,7 @@ class PCA(object):
                 se.snps, se.names, kmeans_imap, "sample", self.quiet).run()
 
             # x. On final iteration return this imputed array as the result
-            if it == 4:
+            if it == niters - 1:
                 return impdata
 
             # 3. subsample unlinked SNPs


### PR DESCRIPTION
`_impute_kmeans` (ipyrad/analysis/pca.py) is ignoring `niters`> 5, since the stopping/return iteration is hardcoded at 4.