### PR TITLE
Solving retro-compatibility in windows extracter

### DIFF
--- a/ipyrad/analysis/window_extracter.py
+++ b/ipyrad/analysis/window_extracter.py
@@ -324,7 +324,13 @@ class WindowExtracter(object):
             except AttributeError:
                 # If "names" aren't encoded as bytes then it's an older version
                 # of the snps.hdf5 file, so allow for this.
-                self.pnames = [i for i in io5["phymap"].attrs["phynames"]]
+
+                #This fix is breaking window_extracter
+                # self.pnames = [i for i in io5["phymap"].attrs["phynames"]] 
+                #My proposal:
+                self.pnames = np.array([
+                    i for i in io5["phymap"].attrs["phynames"]
+                ])
 
             self.allnames = [i.strip() for i in self.pnames]
 
@@ -435,11 +441,24 @@ class WindowExtracter(object):
             # mask to select this scaff
             mask = io5["phymap"][:, 0] == self._scaffold_idx + 1
 
-            # load dataframe of this scaffold
-            self._phymap = pd.DataFrame(
-                data=io5["phymap"][:][mask],
-                columns=[i.decode() for i in colnames],
-            )
+            # load dataframe of this scaffold  
+            # BUG: this piece is not compatible with hdf5 that are not encoded
+            # self._phymap = pd.DataFrame(
+            #     data=io5["phymap"][:][mask],
+            #     columns=[i.decode() for i in colnames],
+            # )
+
+            # My proposal
+            try:
+                self._phymap = pd.DataFrame(
+                    data=io5["phymap"][:][mask],
+                    columns=[i.decode() for i in colnames],
+                )
+            except AttributeError:
+                self._phymap = pd.DataFrame(
+                    data=io5["phymap"][:][mask],
+                    columns=[i for i in colnames],
+                )
 
 
     def _init_stats(self):


### PR DESCRIPTION
Also, I noticed that there is another `decode()` problem in https://github.com/dereneaton/ipyrad/blob/729608b88d2f6edd92c232c389d74c9864fb9afa/ipyrad/analysis/treeslider.py#L270

The fix could be similar. This affects old and also new assemblies (v.0.9.84 to v0.9.87)